### PR TITLE
fixed link for cloning the server: use https://github.com/Urigo/Whats…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Make sure to clone the server first
 
-    $ git clone git@github.com:Urigo/WhatsApp-Clone-server.git
+    $ git clone https://github.com/Urigo/WhatsApp-Clone-Client-React.git
 
 Run yarn
 


### PR DESCRIPTION
This is the error message you'd get when trying to clone from the instruction in the README

```Cloning into 'WhatsApp-Clone-server'...
Warning: Permanently added the RSA host key for IP address 'xxx.8x.11x.x' to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists. ```

I just added the HTTP link.